### PR TITLE
danielsf/rgb/shader/230602

### DIFF
--- a/src/ng_link/__init__.py
+++ b/src/ng_link/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for the generation of neuroglancer links
 """
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 # flake8: noqa: F401
 from ng_link.ng_layer import NgLayer

--- a/src/ng_link/ng_layer.py
+++ b/src/ng_link/ng_layer.py
@@ -1188,12 +1188,18 @@ class ImageLayer:
         """
 
         monochrome_keys = set(['color', 'emitter', 'vec'])
+        rgb_keys = set(['r_range', 'g_range', 'b_range'])
         config_keys = set(shader_config.keys())
         if config_keys == monochrome_keys:
             return shader_utils.create_monochrome_shader(
                 color=shader_config['color'],
                 emitter=shader_config['emitter'],
                 vec=shader_config['vec'])
+        elif config_keys == rgb_keys:
+            return shader_utils.create_rgb_shader(
+                r_range=shader_config['r_range'],
+                g_range=shader_config['g_range'],
+                b_range=shader_config['b_range'])
         else:
             raise RuntimeError(
                 f"Do not know how to create shader code for shader_config "

--- a/src/ng_link/ng_layer.py
+++ b/src/ng_link/ng_layer.py
@@ -14,7 +14,8 @@ from typing import Dict, List, Optional, Union, get_args
 import neuroglancer
 import numpy as np
 
-from .utils import utils
+from .utils import utils, shader_utils
+
 
 # IO types
 PathLike = Union[str, Path]
@@ -1186,28 +1187,18 @@ class ImageLayer:
             String with the shader configuration for neuroglancer.
         """
 
-        color = shader_config["color"]
-        emitter = shader_config["emitter"]
-        vec = shader_config["vec"]
+        monochrome_keys = set(['color', 'emitter', 'vec'])
+        config_keys = set(shader_config.keys())
+        if config_keys == monochrome_keys:
+            return shader_utils.create_monochrome_shader(
+                color=shader_config['color'],
+                emitter=shader_config['emitter'],
+                vec=shader_config['vec'])
+        else:
+            raise RuntimeError(
+                f"Do not know how to create shader code for shader_config "
+                f"with keys {list(shader_config.keys())}")
 
-        # Add all necessary ui controls here
-        ui_controls = [
-            f'#uicontrol {vec} color color(default="{color}")',
-            "#uicontrol invlerp normalized",
-        ]
-
-        # color emitter
-        emit_color = (
-            "void main() {\n" + f"emit{emitter}(color * normalized());" + "\n}"
-        )
-        shader_string = ""
-
-        for ui_control in ui_controls:
-            shader_string += ui_control + "\n"
-
-        shader_string += emit_color
-
-        return shader_string
 
     @property
     def opacity(self) -> str:

--- a/src/ng_link/ng_layer.py
+++ b/src/ng_link/ng_layer.py
@@ -14,8 +14,7 @@ from typing import Dict, List, Optional, Union, get_args
 import neuroglancer
 import numpy as np
 
-from .utils import utils, shader_utils
-
+from .utils import shader_utils, utils
 
 # IO types
 PathLike = Union[str, Path]
@@ -45,7 +44,7 @@ class ObjProxy(NamespaceProxy):
         ]
         DISALLOWED.add("__class__")
         new_dict = {}
-        for (attr, value) in inspect.getmembers(real_cls, callable):
+        for attr, value in inspect.getmembers(real_cls, callable):
             if attr not in DISALLOWED or attr in ALLOWED:
                 new_dict[attr] = cls._proxy_wrap(attr)
         return new_dict
@@ -140,7 +139,6 @@ def generate_precomputed_cells(cells, path, res):
         f.write(json.dumps(metadata))
 
     with open(os.path.join(output_path, "0_0_0"), "wb") as outfile:
-
         start_t = time.time()
 
         total_count = len(cell_list)  # coordinates is a list of tuples (x,y,z)
@@ -148,7 +146,6 @@ def generate_precomputed_cells(cells, path, res):
         print("Running multiprocessing")
 
         if not isinstance(buf, type(None)):
-
             buf.extend(struct.pack("<Q", total_count))
 
             with multiprocessing.Pool(processes=os.cpu_count()) as p:
@@ -162,10 +159,9 @@ def generate_precomputed_cells(cells, path, res):
             )
             buf.extend(id_buf)
         else:
-
             buf = struct.pack("<Q", total_count)
 
-            for (x, y, z) in cell_list:
+            for x, y, z in cell_list:
                 pt_buf = struct.pack("<3f", x, y, z)
                 buf += pt_buf
 
@@ -372,7 +368,6 @@ class SegmentationLayer:
         actual_state = self.__layer_state
 
         if "precomputed://" in source:
-
             write_path = Path(source.replace("precomputed://", ""))
             s3_path = self.__set_s3_path(str(write_path))
 
@@ -635,7 +630,6 @@ class AnnotationLayer:
             actual_state["source"] = f"precomputed://{s3_path}"
 
         else:
-
             actual_state["source"] = source
             actual_state = self.__set_transform(self.output_dimensions)
 
@@ -954,7 +948,6 @@ class ImageLayer:
 
         s3_path = None
         if not orig_source_path.startswith(f"{self.mount_service}://"):
-
             # Work with code ocean
             if "/scratch/" in orig_source_path:
                 orig_source_path = orig_source_path.replace("/scratch/", "")
@@ -1187,24 +1180,26 @@ class ImageLayer:
             String with the shader configuration for neuroglancer.
         """
 
-        monochrome_keys = set(['color', 'emitter', 'vec'])
-        rgb_keys = set(['r_range', 'g_range', 'b_range'])
+        monochrome_keys = set(["color", "emitter", "vec"])
+        rgb_keys = set(["r_range", "g_range", "b_range"])
         config_keys = set(shader_config.keys())
         if config_keys == monochrome_keys:
             return shader_utils.create_monochrome_shader(
-                color=shader_config['color'],
-                emitter=shader_config['emitter'],
-                vec=shader_config['vec'])
+                color=shader_config["color"],
+                emitter=shader_config["emitter"],
+                vec=shader_config["vec"],
+            )
         elif config_keys == rgb_keys:
             return shader_utils.create_rgb_shader(
-                r_range=shader_config['r_range'],
-                g_range=shader_config['g_range'],
-                b_range=shader_config['b_range'])
+                r_range=shader_config["r_range"],
+                g_range=shader_config["g_range"],
+                b_range=shader_config["b_range"],
+            )
         else:
             raise RuntimeError(
                 f"Do not know how to create shader code for shader_config "
-                f"with keys {list(shader_config.keys())}")
-
+                f"with keys {list(shader_config.keys())}"
+            )
 
     @property
     def opacity(self) -> str:

--- a/src/ng_link/ng_state.py
+++ b/src/ng_link/ng_state.py
@@ -70,7 +70,6 @@ class NgState:
         self.initialize_attributes(self.input_config)
 
     def __fix_output_json_path(self, output_json: PathLike) -> str:
-
         """
         Fixes the json output path to have a similar structure for all links.
 
@@ -155,7 +154,6 @@ class NgState:
 
     @dimensions.setter
     def dimensions(self, new_dimensions: dict) -> None:
-
         """
         Set dimensions with voxel sizes for the image.
 
@@ -179,7 +177,6 @@ class NgState:
         regex_axis = r"([x-zX-Z])$"
 
         for axis, axis_values in new_dimensions.items():
-
             if re.search(regex_axis, axis):
                 self.__dimensions[axis] = self.__unpack_axis(axis_values)
             elif axis == "t":
@@ -761,7 +758,6 @@ def dispim_example():
         new_affine_transform = affine_transform.copy()
 
         for n_tile in list_n_tiles:
-
             n_tile = str(n_tile)
 
             if len(n_tile) == 1:
@@ -822,7 +818,6 @@ def dispim_example():
     visible = True
 
     for camera_index in camera_indexes:
-
         if camera_index == 1:
             # Mirror Z stack and apply same angle for cam0
             ng_affine_transform[2, 2] = -1

--- a/src/ng_link/utils/shader_utils.py
+++ b/src/ng_link/utils/shader_utils.py
@@ -1,10 +1,10 @@
+"""
+Module containing utility functions to generate neuroglancer shader code
+"""
 from typing import Tuple
 
 
-def create_monochrome_shader(
-        color: str,
-        emitter: str,
-        vec: str) -> str:
+def create_monochrome_shader(color: str, emitter: str, vec: str) -> str:
     """
     Creates a configuration for the neuroglancer shader.
     This shader generates a monochromatic image.
@@ -46,9 +46,10 @@ def create_monochrome_shader(
 
 
 def create_rgb_shader(
-        r_range: Tuple[int, int],
-        g_range: Tuple[int, int],
-        b_range: Tuple[int, int]) -> str:
+    r_range: Tuple[int, int],
+    g_range: Tuple[int, int],
+    b_range: Tuple[int, int],
+) -> str:
     """
     Return shader code for an RGB image with different dynamic
     ranges for each channel.
@@ -64,7 +65,7 @@ def create_rgb_shader(
 
     Returns
     -------
-    code: str
+    str
         String containing the shader code for a neuroglancer
         RGB image.
     """

--- a/src/ng_link/utils/shader_utils.py
+++ b/src/ng_link/utils/shader_utils.py
@@ -1,3 +1,6 @@
+from typing import Tuple
+
+
 def create_monochrome_shader(
         color: str,
         emitter: str,
@@ -40,3 +43,42 @@ def create_monochrome_shader(
     shader_string += emit_color
 
     return shader_string
+
+
+def create_rgb_shader(
+        r_range: Tuple[int, int],
+        g_range: Tuple[int, int],
+        b_range: Tuple[int, int]) -> str:
+    """
+    Return shader code for an RGB image with different dynamic
+    ranges for each channel.
+
+    Parameters
+    ----------
+    r_range: Tuple[int, int]
+        Dynamic range of the R channel (min, max)
+    g_range: Tuple[int, int]
+        Dynamic range of the G channel (min, max)
+    b_range: Tuple[int, int[
+        Dynamic range of the B channel (min, max)
+
+    Returns
+    -------
+    code: str
+        String containing the shader code for a neuroglancer
+        RGB image.
+    """
+
+    code = "#uicontrol invlerp "
+    code += f"normalized_r(range=[{r_range[0]}, {r_range[1]}])\n"
+    code += "#uicontrol invlerp "
+    code += f"normalized_g(range=[{g_range[0]}, {g_range[1]}])\n"
+    code += "#uicontrol invlerp "
+    code += f"normalized_b(range=[{b_range[0]}, {b_range[1]}])\n"
+    code += "void main(){\n"
+    code += "float r = normalized_r(getDataValue(0));\n"
+    code += "float g = normalized_g(getDataValue(1));\n"
+    code += "float b = normalized_b(getDataValue(2));\n"
+    code += "emitRGB(vec3(r, g, b));\n}\n"
+
+    return code

--- a/src/ng_link/utils/shader_utils.py
+++ b/src/ng_link/utils/shader_utils.py
@@ -1,0 +1,42 @@
+def create_monochrome_shader(
+        color: str,
+        emitter: str,
+        vec: str) -> str:
+    """
+    Creates a configuration for the neuroglancer shader.
+    This shader generates a monochromatic image.
+
+    Parameters
+    ------------------------
+    color:  str
+        The color of the monochromatic image
+    emitter: str
+        suffix of WebGL emit* method being called (e.g. 'RGB')
+    vec: str
+        class of vector we want color returned as in WebGL
+        (e.g. 'vec3')
+
+    Returns
+    ------------------------
+    str
+        String with the shader configuration for neuroglancer.
+    """
+
+    # Add all necessary ui controls here
+    ui_controls = [
+        f'#uicontrol {vec} color color(default="{color}")',
+        "#uicontrol invlerp normalized",
+    ]
+
+    # color emitter
+    emit_color = (
+        "void main() {\n" + f"emit{emitter}(color * normalized());" + "\n}"
+    )
+    shader_string = ""
+
+    for ui_control in ui_controls:
+        shader_string += ui_control + "\n"
+
+    shader_string += emit_color
+
+    return shader_string

--- a/src/ng_link/utils/utils.py
+++ b/src/ng_link/utils/utils.py
@@ -74,7 +74,6 @@ def execute_command_helper(
     print_command: bool = False,
     stdout_log_file: Optional[PathLike] = None,
 ) -> None:
-
     """
     Execute a shell command.
 
@@ -194,7 +193,6 @@ def save_dict_as_json(
 
 
 def read_json_as_dict(filepath: str) -> dict:
-
     """
     Reads a json as dictionary.
 

--- a/tests/test_ng_layer.py
+++ b/tests/test_ng_layer.py
@@ -1,6 +1,7 @@
 """Tests ng layer class methods."""
-import pytest
 import unittest
+
+import pytest
 
 from ng_link.ng_layer import ImageLayer
 
@@ -13,24 +14,22 @@ class NgLayerTest(unittest.TestCase):
         Test that ImageLayer can generate a monochromatic shader
         """
         image_config = {
-            "shader": {
-                "color": "green",
-                "emitter": "RGB",
-                "vec": "vec3"},
-            "source": "bogus.zarr"
+            "shader": {"color": "green", "emitter": "RGB", "vec": "vec3"},
+            "source": "bogus.zarr",
         }
 
         layer = ImageLayer(
             image_config=image_config,
             mount_service="s3",
             bucket_path="silly/bucket",
-            output_dimensions=dict())
+            output_dimensions=dict(),
+        )
 
         expected = '#uicontrol vec3 color color(default="green")\n'
-        expected += '#uicontrol invlerp normalized\n'
-        expected += 'void main() {\n'
-        expected += 'emitRGB(color * normalized());\n'
-        expected += '}'
+        expected += "#uicontrol invlerp normalized\n"
+        expected += "void main() {\n"
+        expected += "emitRGB(color * normalized());\n"
+        expected += "}"
 
         assert layer.shader == expected
 
@@ -42,15 +41,17 @@ class NgLayerTest(unittest.TestCase):
             "shader": {
                 "r_range": (1, 9),
                 "g_range": (18, 37),
-                "b_range": (0, 100)},
-            "source": "bogus.zarr"
+                "b_range": (0, 100),
+            },
+            "source": "bogus.zarr",
         }
 
         layer = ImageLayer(
             image_config=image_config,
             mount_service="s3",
             bucket_path="silly/bucket",
-            output_dimensions=dict())
+            output_dimensions=dict(),
+        )
 
         expected = "#uicontrol invlerp "
         expected += "normalized_r(range=[1, 9])\n"
@@ -69,11 +70,7 @@ class NgLayerTest(unittest.TestCase):
         Test that ImageLayer gives the expected failure
         when given nonsense image config paramters
         """
-        image_config = {
-            "shader": {
-                "foo": "bar"},
-            "source": "bogus.zarr"
-        }
+        image_config = {"shader": {"foo": "bar"}, "source": "bogus.zarr"}
 
         msg = "Do not know how to create shader code"
         with pytest.raises(RuntimeError, match=msg):
@@ -81,7 +78,8 @@ class NgLayerTest(unittest.TestCase):
                 image_config=image_config,
                 mount_service="s3",
                 bucket_path="silly/bucket",
-                output_dimensions=dict())
+                output_dimensions=dict(),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_ng_layer.py
+++ b/tests/test_ng_layer.py
@@ -34,6 +34,36 @@ class NgLayerTest(unittest.TestCase):
 
         assert layer.shader == expected
 
+    def test_image_layer_rgb_shader(self):
+        """
+        Test that ImageLayer can generate a RGB shader
+        """
+        image_config = {
+            "shader": {
+                "r_range": (1, 9),
+                "g_range": (18, 37),
+                "b_range": (0, 100)},
+            "source": "bogus.zarr"
+        }
+
+        layer = ImageLayer(
+            image_config=image_config,
+            mount_service="s3",
+            bucket_path="silly/bucket",
+            output_dimensions=dict())
+
+        expected = "#uicontrol invlerp "
+        expected += "normalized_r(range=[1, 9])\n"
+        expected += "#uicontrol invlerp normalized_g(range=[18, 37])\n"
+        expected += "#uicontrol invlerp normalized_b(range=[0, 100])\n"
+        expected += "void main(){\n"
+        expected += "float r = normalized_r(getDataValue(0));\n"
+        expected += "float g = normalized_g(getDataValue(1));\n"
+        expected += "float b = normalized_b(getDataValue(2));\n"
+        expected += "emitRGB(vec3(r, g, b));\n}\n"
+
+        assert layer.shader == expected
+
     def test_image_layer_shader_failure(self):
         """
         Test that ImageLayer gives the expected failure

--- a/tests/test_ng_layer.py
+++ b/tests/test_ng_layer.py
@@ -1,8 +1,6 @@
 """Tests ng layer class methods."""
 import unittest
 
-import pytest
-
 from ng_link.ng_layer import ImageLayer
 
 
@@ -31,7 +29,7 @@ class NgLayerTest(unittest.TestCase):
         expected += "emitRGB(color * normalized());\n"
         expected += "}"
 
-        assert layer.shader == expected
+        self.assertEqual(layer.shader, expected)
 
     def test_image_layer_rgb_shader(self):
         """
@@ -63,7 +61,7 @@ class NgLayerTest(unittest.TestCase):
         expected += "float b = normalized_b(getDataValue(2));\n"
         expected += "emitRGB(vec3(r, g, b));\n}\n"
 
-        assert layer.shader == expected
+        self.assertEqual(layer.shader, expected)
 
     def test_image_layer_shader_failure(self):
         """
@@ -72,14 +70,15 @@ class NgLayerTest(unittest.TestCase):
         """
         image_config = {"shader": {"foo": "bar"}, "source": "bogus.zarr"}
 
-        msg = "Do not know how to create shader code"
-        with pytest.raises(RuntimeError, match=msg):
-            ImageLayer(
-                image_config=image_config,
-                mount_service="s3",
-                bucket_path="silly/bucket",
-                output_dimensions=dict(),
-            )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Do not know how to create shader code",
+            ImageLayer,
+            image_config=image_config,
+            mount_service="s3",
+            bucket_path="silly/bucket",
+            output_dimensions=dict(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_ng_layer.py
+++ b/tests/test_ng_layer.py
@@ -1,12 +1,57 @@
 """Tests ng layer class methods."""
-
+import pytest
 import unittest
+
+from ng_link.ng_layer import ImageLayer
 
 
 class NgLayerTest(unittest.TestCase):
     """Tests ng layer class methods."""
 
-    pass
+    def test_image_layer_monochrome_shader(self):
+        """
+        Test that ImageLayer can generate a monochromatic shader
+        """
+        image_config = {
+            "shader": {
+                "color": "green",
+                "emitter": "RGB",
+                "vec": "vec3"},
+            "source": "bogus.zarr"
+        }
+
+        layer = ImageLayer(
+            image_config=image_config,
+            mount_service="s3",
+            bucket_path="silly/bucket",
+            output_dimensions=dict())
+
+        expected = '#uicontrol vec3 color color(default="green")\n'
+        expected += '#uicontrol invlerp normalized\n'
+        expected += 'void main() {\n'
+        expected += 'emitRGB(color * normalized());\n'
+        expected += '}'
+
+        assert layer.shader == expected
+
+    def test_image_layer_shader_failure(self):
+        """
+        Test that ImageLayer gives the expected failure
+        when given nonsense image config paramters
+        """
+        image_config = {
+            "shader": {
+                "foo": "bar"},
+            "source": "bogus.zarr"
+        }
+
+        msg = "Do not know how to create shader code"
+        with pytest.raises(RuntimeError, match=msg):
+            ImageLayer(
+                image_config=image_config,
+                mount_service="s3",
+                bucket_path="silly/bucket",
+                output_dimensions=dict())
 
 
 if __name__ == "__main__":

--- a/tests/test_shader_utils.py
+++ b/tests/test_shader_utils.py
@@ -1,22 +1,21 @@
-from ng_link.utils.shader_utils import (
-    create_monochrome_shader,
-    create_rgb_shader)
+"""
+Tests of utility functions for generating neuroglancer shader code
+"""
+from ng_link.utils.shader_utils import (create_monochrome_shader,
+                                        create_rgb_shader)
 
 
 def test_monochrome_shader():
     """
     Just test that create_monochrome_shader runs.
     """
-    result = create_monochrome_shader(
-        color='green',
-        emitter='RGB',
-        vec='vec3')
+    result = create_monochrome_shader(color="green", emitter="RGB", vec="vec3")
 
     expected = '#uicontrol vec3 color color(default="green")\n'
-    expected += '#uicontrol invlerp normalized\n'
-    expected += 'void main() {\n'
-    expected += 'emitRGB(color * normalized());\n'
-    expected += '}'
+    expected += "#uicontrol invlerp normalized\n"
+    expected += "void main() {\n"
+    expected += "emitRGB(color * normalized());\n"
+    expected += "}"
 
     assert result == expected
 
@@ -26,9 +25,8 @@ def test_rgb_shader():
     Test that create_rgb_shader runs
     """
     result = create_rgb_shader(
-        r_range=(1, 9),
-        g_range=(18, 37),
-        b_range=(0, 100))
+        r_range=(1, 9), g_range=(18, 37), b_range=(0, 100)
+    )
 
     expected = "#uicontrol invlerp "
     expected += "normalized_r(range=[1, 9])\n"

--- a/tests/test_shader_utils.py
+++ b/tests/test_shader_utils.py
@@ -1,0 +1,20 @@
+from ng_link.utils.shader_utils import (
+    create_monochrome_shader)
+
+
+def test_monochrome_shader():
+    """
+    Just test that create_monochrome_shader runs.
+    """
+    result = create_monochrome_shader(
+        color='green',
+        emitter='RGB',
+        vec='vec3')
+
+    expected = '#uicontrol vec3 color color(default="green")\n'
+    expected += '#uicontrol invlerp normalized\n'
+    expected += 'void main() {\n'
+    expected += 'emitRGB(color * normalized());\n'
+    expected += '}'
+
+    assert result == expected

--- a/tests/test_shader_utils.py
+++ b/tests/test_shader_utils.py
@@ -1,5 +1,6 @@
 from ng_link.utils.shader_utils import (
-    create_monochrome_shader)
+    create_monochrome_shader,
+    create_rgb_shader)
 
 
 def test_monochrome_shader():
@@ -16,5 +17,27 @@ def test_monochrome_shader():
     expected += 'void main() {\n'
     expected += 'emitRGB(color * normalized());\n'
     expected += '}'
+
+    assert result == expected
+
+
+def test_rgb_shader():
+    """
+    Test that create_rgb_shader runs
+    """
+    result = create_rgb_shader(
+        r_range=(1, 9),
+        g_range=(18, 37),
+        b_range=(0, 100))
+
+    expected = "#uicontrol invlerp "
+    expected += "normalized_r(range=[1, 9])\n"
+    expected += "#uicontrol invlerp normalized_g(range=[18, 37])\n"
+    expected += "#uicontrol invlerp normalized_b(range=[0, 100])\n"
+    expected += "void main(){\n"
+    expected += "float r = normalized_r(getDataValue(0));\n"
+    expected += "float g = normalized_g(getDataValue(1));\n"
+    expected += "float b = normalized_b(getDataValue(2));\n"
+    expected += "emitRGB(vec3(r, g, b));\n}\n"
 
     assert result == expected

--- a/tests/test_shader_utils.py
+++ b/tests/test_shader_utils.py
@@ -1,41 +1,51 @@
 """
 Tests of utility functions for generating neuroglancer shader code
 """
+import unittest
+
 from ng_link.utils.shader_utils import (create_monochrome_shader,
                                         create_rgb_shader)
 
 
-def test_monochrome_shader():
-    """
-    Just test that create_monochrome_shader runs.
-    """
-    result = create_monochrome_shader(color="green", emitter="RGB", vec="vec3")
+class ShaderUtilsTest(unittest.TestCase):
+    """Class to contain tests of shader utils"""
 
-    expected = '#uicontrol vec3 color color(default="green")\n'
-    expected += "#uicontrol invlerp normalized\n"
-    expected += "void main() {\n"
-    expected += "emitRGB(color * normalized());\n"
-    expected += "}"
+    def test_monochrome_shader(self):
+        """
+        Just test that create_monochrome_shader runs.
+        """
+        result = create_monochrome_shader(
+            color="green", emitter="RGB", vec="vec3"
+        )
 
-    assert result == expected
+        expected = '#uicontrol vec3 color color(default="green")\n'
+        expected += "#uicontrol invlerp normalized\n"
+        expected += "void main() {\n"
+        expected += "emitRGB(color * normalized());\n"
+        expected += "}"
+
+        self.assertEqual(result, expected)
+
+    def test_rgb_shader(self):
+        """
+        Test that create_rgb_shader runs
+        """
+        result = create_rgb_shader(
+            r_range=(1, 9), g_range=(18, 37), b_range=(0, 100)
+        )
+
+        expected = "#uicontrol invlerp "
+        expected += "normalized_r(range=[1, 9])\n"
+        expected += "#uicontrol invlerp normalized_g(range=[18, 37])\n"
+        expected += "#uicontrol invlerp normalized_b(range=[0, 100])\n"
+        expected += "void main(){\n"
+        expected += "float r = normalized_r(getDataValue(0));\n"
+        expected += "float g = normalized_g(getDataValue(1));\n"
+        expected += "float b = normalized_b(getDataValue(2));\n"
+        expected += "emitRGB(vec3(r, g, b));\n}\n"
+
+        self.assertEqual(result, expected)
 
 
-def test_rgb_shader():
-    """
-    Test that create_rgb_shader runs
-    """
-    result = create_rgb_shader(
-        r_range=(1, 9), g_range=(18, 37), b_range=(0, 100)
-    )
-
-    expected = "#uicontrol invlerp "
-    expected += "normalized_r(range=[1, 9])\n"
-    expected += "#uicontrol invlerp normalized_g(range=[18, 37])\n"
-    expected += "#uicontrol invlerp normalized_b(range=[0, 100])\n"
-    expected += "void main(){\n"
-    expected += "float r = normalized_r(getDataValue(0));\n"
-    expected += "float g = normalized_g(getDataValue(1));\n"
-    expected += "float b = normalized_b(getDataValue(2));\n"
-    expected += "emitRGB(vec3(r, g, b));\n}\n"
-
-    assert result == expected
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds the ability to create shader code for an RGB image into the `ImageLayer` class.

I moved the functions to actually create shader code into a separate `shader_utils` modules, since they don't actually depend on any data carried around by the `ImageLayer` instance.

Just for the sake of posterity:

Here is an example of this shader code working "in the wild"

https://bit.ly/45tDipN

it depends on the name of the channel axis in .zattrs ending with a `^`. There's a bug in neuroglancer with respect to that behavior (or a bug in my understanding of what neuroglancer should be doing). That is being hashed out here

https://github.com/google/neuroglancer/issues/467