### PR TITLE
Adds dataset_name parameter to NgState

### DIFF
--- a/src/ng_link/__init__.py
+++ b/src/ng_link/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for the generation of neuroglancer links
 """
-__version__ = "1.0.10"
+__version__ = "1.0.11"
 
 # flake8: noqa: F401
 from ng_link.ng_layer import NgLayer

--- a/src/ng_link/dispim_link.py
+++ b/src/ng_link/dispim_link.py
@@ -175,7 +175,7 @@ def generate_dispim_link(
         input_config=input_config,
         mount_service="s3",
         bucket_path=f"{bucket_name}",
-        output_json=output_json_path,
+        output_dir=output_json_path,
         base_url="https://aind-neuroglancer-sauujisjxq-uw.a.run.app/",
     )
     neuroglancer_link.save_state_as_json()

--- a/src/ng_link/exaspim_link.py
+++ b/src/ng_link/exaspim_link.py
@@ -45,7 +45,10 @@ def generate_exaspim_link(
     s3_path: str
         Path of s3 bucket where exaspim dataset is located.
     output_json_path: str
-        Local path to write process_output.json file that nueroglancer reads.
+        Local directory to write process_output.json file that nueroglancer reads.
+    dataset_name: Optional[str]
+        Name of dataset. If None, will be directory name of output_json_path.
+    
 
     Returns
     ------------------------

--- a/src/ng_link/exaspim_link.py
+++ b/src/ng_link/exaspim_link.py
@@ -45,10 +45,12 @@ def generate_exaspim_link(
     s3_path: str
         Path of s3 bucket where exaspim dataset is located.
     output_json_path: str
-        Local directory to write process_output.json file that nueroglancer reads.
+        Local directory to write process_output.json file that
+        neuroglancer reads.
     dataset_name: Optional[str]
-        Name of dataset. If None, will be directory name of output_json_path.
-    
+        Name of dataset. If None, will be directory name of
+        output_json_path.
+
 
     Returns
     ------------------------

--- a/src/ng_link/exaspim_link.py
+++ b/src/ng_link/exaspim_link.py
@@ -121,7 +121,8 @@ def generate_exaspim_link(
         input_config=input_config,
         mount_service="s3",
         bucket_path="aind-open-data",
-        output_json=output_json_path,
+        output_dir=output_json_path,
+        dataset_name=dataset_name
     )
     neuroglancer_link.save_state_as_json()
     print(neuroglancer_link.get_url_link())

--- a/src/ng_link/exaspim_link.py
+++ b/src/ng_link/exaspim_link.py
@@ -1,6 +1,8 @@
 """
 Library for generating exaspim link.
 """
+from typing import Optional
+
 import numpy as np
 
 from ng_link import NgState, link_utils, xml_parsing
@@ -128,7 +130,7 @@ def generate_exaspim_link(
         mount_service="s3",
         bucket_path="aind-open-data",
         output_dir=output_json_path,
-        dataset_name=dataset_name
+        dataset_name=dataset_name,
     )
     neuroglancer_link.save_state_as_json()
     print(neuroglancer_link.get_url_link())

--- a/src/ng_link/exaspim_link.py
+++ b/src/ng_link/exaspim_link.py
@@ -33,6 +33,7 @@ def generate_exaspim_link(
     opacity: float = 1.0,
     blend: str = "default",
     output_json_path: str = ".",
+    dataset_name: Optional[str] = None,
 ) -> None:
     """Creates an neuroglancer link to visualize
     registration transforms on exaspim dataset pre-fusion.

--- a/src/ng_link/ng_state.py
+++ b/src/ng_link/ng_state.py
@@ -26,10 +26,11 @@ class NgState:
         input_config: dict,
         mount_service: str,
         bucket_path: str,
-        output_json: PathLike,
+        output_dir: PathLike,
         verbose: Optional[bool] = False,
         base_url: Optional[str] = "https://neuroglancer-demo.appspot.com/",
         json_name: Optional[str] = "process_output.json",
+        dataset_name: Optional[str] = None,
     ) -> None:
         """
         Class constructor
@@ -42,24 +43,30 @@ class NgState:
             Could be 'gs' for a bucket in Google Cloud or 's3' in Amazon.
         bucket_path: str
             Path in cloud service where the dataset will be saved
-        output_json: PathLike
-            Path where the json will be written.
+        output_dir: PathLike
+            Directory where the json will be written.
         verbose: Optional[bool]
             If true, additional information will be shown. Default False.
         base_url: Optional[str]
             Neuroglancer service url
         json_name: Optional[str]
             Name of json file with neuroglancer configuration
+        dataset_name: Optional[str]
+            Name of the dataset. If None, the name of the output_dir directory will be used.
 
         """
 
         self.input_config = input_config
-        self.output_json = Path(self.__fix_output_json_path(output_json))
+        self.output_json = Path(self.__fix_output_json_path(output_dir))
         self.verbose = verbose
         self.mount_service = mount_service
         self.bucket_path = bucket_path
         self.base_url = base_url
         self.json_name = json_name
+        # Component after S3 bucket and before filename in the "ng_link" field of the output JSON
+        self.dataset_name = dataset_name
+        if self.dataset_name is None:
+            self.dataset_name = Path(self.output_json).stem
 
         # State and layers attributes
         self.__state = {}
@@ -407,10 +414,7 @@ class NgState:
             Neuroglancer url to visualize data.
         """
 
-        dataset_name = Path(self.output_json.stem)
-
-        json_path = str(dataset_name.joinpath(self.json_name))
-        json_path = f"{self.mount_service}://{self.bucket_path}/{json_path}"
+        json_path = f"{self.mount_service}://{self.bucket_path}/{self.dataset_name}/{self.json_name}"
 
         link = f"{self.base_url}#!{json_path}"
 
@@ -503,7 +507,7 @@ def smartspim_example():
         input_config=example_data,
         mount_service="s3",
         bucket_path="aind-msma-data",
-        output_json="/Users/camilo.laiton/repositories/aind-ng-link/src",
+        output_dir="/Users/camilo.laiton/repositories/aind-ng-link/src",
     )
 
     data = neuroglancer_link.state
@@ -643,7 +647,7 @@ def exaspim_example():
         input_config=example_data,
         mount_service="s3",
         bucket_path="aind-msma-data",
-        output_json="/Users/camilo.laiton/repositories/aind-ng-link/src",
+        output_dir="/Users/camilo.laiton/repositories/aind-ng-link/src",
     )
 
     data = neuroglancer_link.state
@@ -692,7 +696,7 @@ def example_3(cells):
         input_config=example_data,
         mount_service="s3",
         bucket_path="aind-msma-data",
-        output_json="/Users/camilo.laiton/repositories/aind-ng-link/src",
+        output_dir="/Users/camilo.laiton/repositories/aind-ng-link/src",
     )
 
     data = neuroglancer_link.state
@@ -880,7 +884,7 @@ def dispim_example():
         input_config=example_data,
         mount_service="s3",
         bucket_path="aind-msma-data",
-        output_json="/Users/camilo.laiton/repositories/aind-ng-link/src",
+        output_dir="/Users/camilo.laiton/repositories/aind-ng-link/src",
     )
 
     data = neuroglancer_link.state

--- a/src/ng_link/raw_link.py
+++ b/src/ng_link/raw_link.py
@@ -109,7 +109,7 @@ def generate_raw_link(
         input_config=input_config,
         mount_service="s3",
         bucket_path="aind-open-data",
-        output_json=output_json_path,
+        output_dir=output_json_path,
     )
     neuroglancer_link.save_state_as_json()
     print(neuroglancer_link.get_url_link())

--- a/src/ng_link/scripts/generate_cff_cell_count.py
+++ b/src/ng_link/scripts/generate_cff_cell_count.py
@@ -187,7 +187,7 @@ def generate_25_um_ccf_cells(params: dict, micron_res: int = 25):
         input_config=ccf_cell_count,
         mount_service="s3",
         bucket_path="aind-msma-data",
-        output_json="/Users/camilo.laiton/repositories/new_ng_link/aind-ng-link",
+        output_dir="/Users/camilo.laiton/repositories/new_ng_link/aind-ng-link",
     )
 
     return neuroglancer_link


### PR DESCRIPTION
This PR adds an optional `dataset_name` parameter to the `NgState`. The dataset name is the path component after the bucket and before the json filename, for example, `s3://aind-open-data/dataset_name/process_output.json`. The dataset name is used to create the `ng_link` field of the written JSON data, which neuroglancer reads to create a viewer state.

Currently, the dataset name is hard-coded as the name of the output json directory. This makes sense if you always write the json file to a directory with the same name as the dataset, but this scenario is uncommon when working in the cloud, and is less flexible in general. Therefore, it is useful to specify the name of the dataset so a correct link can be generated when writing to any directory.